### PR TITLE
Fix `testStartProtocolWithoutHostMsg` unittest

### DIFF
--- a/ZenPacks/zenoss/NtpMonitor/tests/testNtpProtocol.py
+++ b/ZenPacks/zenoss/NtpMonitor/tests/testNtpProtocol.py
@@ -322,7 +322,7 @@ class TestNtpProtocolStatic(unittest.TestCase):
 
     def testStartProtocolWithoutHostMsg(self):
         def final(err):
-            errMsg = "Host is not specified"
+            errMsg = "Host is not specified. Please check hostname"
             self.assertEqual(err.getErrorMessage(), errMsg)
 
         d = Deferred()


### PR DESCRIPTION
Fixes [ZEN-30532](https://jira.zenoss.com/browse/ZEN-30532).

See change: https://github.com/zenoss/ZenPacks.zenoss.NtpMonitor/commit/27d4c5f0dee9350999c4376c1f154c6733dc84f8#diff-af837e0c7d6021b1dc0b629977f6f0deR417