### PR TITLE
Fix `testStartProtocolWithoutHostMsg` unittest

### DIFF
--- a/ZenPacks/zenoss/NtpMonitor/tests/testNtpProtocol.py
+++ b/ZenPacks/zenoss/NtpMonitor/tests/testNtpProtocol.py
@@ -322,7 +322,7 @@ class TestNtpProtocolStatic(unittest.TestCase):
 
     def testStartProtocolWithoutHostMsg(self):
         def final(err):
-            errMsg = "Host is not specified"
+            errMsg = "Host is not specified. Please check hostname"
             self.assertEqual(err.getErrorMessage(), errMsg)
 
         d = Deferred()


### PR DESCRIPTION
Fixes [ZPS-4450](https://jira.zenoss.com/browse/ZPS-4450).